### PR TITLE
Proposed naming changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ There are three main objects in the Reactor architecture:
 
 ## State
 
-State is anything that conforms to `StateType`. Here is an example:
+State is anything that conforms to `State`. Here is an example:
 
 ```swift
-struct Player: StateType {
+struct Player: State {
     var name: String
     var level: Int
-    
+
     mutating func handle(event: Event) {
         switch event {
         case let _ as LevelUp:
@@ -56,10 +56,10 @@ struct Player: StateType {
 Here we have a simple `Player` model, which is state in our application. Obviously most application states are more complicated than this, but this is where composition comes into play: we can create state by composing states.
 
 ```swift
-struct RPGState: StateType {
+struct RPGState: State {
     var player: Player
     var monsters: Monsters
-    
+
     mutating func handle(event: Event) {
         player.handle(event: event)
         monsters.handle(event: event)
@@ -110,16 +110,16 @@ class ViewController: UIViewController {
         super.viewDidAppear(animated)
         reactor.add(subscriber: self)
     }
-    
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         reactor.remove(subscriber: self)
     }
-    
+
     @IBAction func didPressDecrement() {
         reactor.perform(event: Decrement())
     }
-    
+
     @IBAction func didPressIncrement() {
         reactor.perform(event: Increment())
     }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ struct Player: State {
     var name: String
     var level: Int
 
-    mutating func handle(event: Event) {
+    mutating func react(to event: Event) {
         switch event {
         case let _ as LevelUp:
             level += 1
@@ -60,14 +60,14 @@ struct RPGState: State {
     var player: Player
     var monsters: Monsters
 
-    mutating func handle(event: Event) {
-        player.handle(event: event)
-        monsters.handle(event: event)
+    mutating func react(to event: Event) {
+        player.react(to: event)
+        monsters.react(to: event)
     }
 }
 ```
 
-Parent states can handle events however they wish, although this will in most cases involve delegating to substates default behavior.
+Parent states can react to events however they wish, although this will in most cases involve delegating to substates default behavior.
 
 Side note: does the sight of `mutating` make you feel impure? Have no fear, [`mutating` semantics on value types](http://chris.eidhof.nl/post/structs-and-mutation-in-swift/) here are actualy very safe in Swift, and it gives us an imperative look and feel, with the safety of functional programming.
 
@@ -97,7 +97,7 @@ struct Update<T>: Event {
 
 ## Tying it Together with the Reactor
 
-So, how does the state get events? Since the `Reactor` is responsible for all `State` changes, you can send events to the reactor which will in turn update the state by calling `handle(event: Event)` on the root state. You can create a shared global `Reactor` used by your entire application (my suggestion), or tediously pass the reference from object to object if you're a masochist.
+So, how does the state get events? Since the `Reactor` is responsible for all `State` changes, you can send events to the reactor which will in turn update the state by calling `react(to event: Event)` on the root state. You can create a shared global `Reactor` used by your entire application (my suggestion), or tediously pass the reference from object to object if you're a masochist.
 
 Here is an example of a view controller with increment and decrement buttons and a label.
 
@@ -140,7 +140,7 @@ Sometimes you want to do something with an event besides just update application
 
 ```swift
 struct LoggingMiddleware: Middleware {
-        func handle(event: Event, state: State) {
+        func process(event: Event, state: State) {
         switch event {
         case _ as Increment:
             print("Increment!")

--- a/Sources/Reactor.swift
+++ b/Sources/Reactor.swift
@@ -3,22 +3,22 @@ import Foundation
 public protocol Event {}
 
 public protocol State {
-    mutating func handle(event: Event)
+    mutating func react(to event: Event)
 }
 
 public protocol AnyMiddleware {
-    func _handle(event: Event, state: Any)
+    func _process(event: Event, state: Any)
 }
 
 public protocol Middleware: AnyMiddleware {
     associatedtype State
-    func handle(event: Event, state: State)
+    func process(event: Event, state: State)
 }
 
 extension Middleware {
-    public func _handle(event: Event, state: Any) {
+    public func _process(event: Event, state: Any) {
         if let state = state as? State {
-            handle(event: event, state: state)
+            process(event: event, state: state)
         }
     }
 }
@@ -100,8 +100,8 @@ public class Reactor<ReactorState: State> {
     // MARK: - Events
     
     public func perform(event: Event) {
-        state.handle(event: event)
-        middlewares.forEach { $0.middleware._handle(event: event, state: state) }
+        state.react(to: event)
+        middlewares.forEach { $0.middleware._process(event: event, state: state) }
     }
     
     public func perform(eventCreator: EventEmitter) {


### PR DESCRIPTION
**Developers should use `State`**

Their code should be clean, so make give developers the simple name to use when making their states conform to the required protocol.

Rename `StateType` to `State`. This means that the thing formerly known as `State` is now `ReactorState`, which is fine since its an alias almost exclusively used inside Reactor code. As such, I don't think the user documentation should mention that detail.

**`handle` is not specific**

A `State` often changes when it receives an event. That change is in reaction to the event. Therefore, change the mutating function's name to `react(to event: Event)`.

Middleware shouldn't change anything in response to an event. Hint at the idea of "work without side effects" by making that function's name `process(event: Event)`.
