### PR TITLE
Namespacing Fix - Rename to Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Reactor encourages unidirectional data flow from a single source of truth—i.e.
 There are six objects in the Reactor architecture:
 
 1. The `State` object - A struct with properties representing application data.
-1. The `Core` - Holds the application state.
-1. The `Event` - Can be fired by the core to trigger a state update.
+1. The `Event` - Can trigger a state update.
+1. The `Core` - Holds the application state and responsible for firing events.
 1. The `Subscriber` - Often a view controller, listens for state updates.
 1. The `Command` - A task that can asynchronously fire events. Useful for networking, working with databases, or any other asynchronous task.
 1. `Middleware` - Receives every event and corresponding state. Useful for analytics, error handling, and other side effects.
@@ -140,7 +140,7 @@ class PlayerViewController: UIViewController {
     }
 }
 
-extension ViewController: Subscriber {
+extension ViewController: Reactor.Subscriber {
     func update(with state: State) {
         levelLabel?.text = String(state.count)
     }
@@ -172,7 +172,7 @@ struct CreatePlayer: Command {
 core.fire(command: CreatePlayer(player: myNewPlayer))
 ```
 
-Commands get a copy of the current state, and a reference to the Core so they can fire Events as necessary.
+Commands get a copy of the current state, and a reference to the Core which allows them to fire Events as necessary.
 
 ## Middleware
 
@@ -190,5 +190,3 @@ struct LoggingMiddleware: Middleware {
     }
 }
 ```
-
-Obviously, in order to scale such middleware you would probably want to implement a way to encode/decode events, but at least you get an idea of what's possible

--- a/README.md
+++ b/README.md
@@ -10,28 +10,47 @@ Reactor encourages unidirectional data flow from a single source of truth—i.e.
 ## Architecture
 
 ```
-┌──────────────────┐                                 ┌──────────────────┐
-│                  │                                 │                  │
-│                  │         ┌───────────┐           │                  │
-│                  │◀────────┤   Event   ├───────────┤                  │
+                                                     ┌──────────────────┐
+                                                     │                  │
+                                                     │                  │
+                                                     │     Command      │
+                                                 ┌───│     (Async)      │
+                                                 │   │                  │
+                                                 │   │                  │
+                                                 │   └──────────────────┘
+                                                 │
+┌──────────────────┐                             │   ┌──────────────────┐
+│                  │                             │   │                  │
+│                  │         ┌───────────┐       │   │                  │
+│                  │◀────────┤   Event   ├────◀──┴───┤                  │
 │                  │         └───────────┘           │                  │
 │                  │                                 │                  │
+│       Core       │                                 │    Subscriber    │
 │                  │                                 │                  │
-│     Reactor      │                                 │    Subscriber    │
 │                  │                                 │                  │
-│                  │         ┌───────────┐           │                  │
-│    ┌───────┐     ├─────────┤  update   ├──────────▶│                  │
-│    │ State │     │         └───────────┘           │                  │
-│    └───────┘     │                                 │                  │
-│                  │                                 │                  │
-└──────────────────┘                                 └──────────────────┘
+│    ┌───────┐     │         ┌───────────┐           │                  │
+│    │ State │     ├─────────┤   State   ├───────┬──▶│                  │
+│    └───────┘     │         └───────────┘       │   │                  │
+│                  │                             │   │                  │
+└──────────────────┘                             │   └──────────────────┘
+                                                 │
+                                                 │   ┌──────────────────┐
+                                                 │   │                  │
+                                                 │   │                  │
+                                                 └──▶│    Middleware    │
+                                                     │                  │
+                                                     │                  │
+                                                     └──────────────────┘
 ```
 
-There are three main objects in the Reactor architecture:
+There are six objects in the Reactor architecture:
 
-1. The application `State`
-2. The `Reactor`, which holds the application `State` and is the only object that can change it.
-3. The `Subscriber` (often a view controller), which listens and receives the updated `State` whenever
+1. The `State` object - A struct with properties representing application data.
+1. The `Core` - Holds the application state.
+1. The `Event` - Can be fired by the core to trigger a state update.
+1. The `Subscriber` - Often a view controller, listens for state updates.
+1. The `Command` - A task that can asynchronously fire events. Useful for networking, working with databases, or any other asynchronous task.
+1. `Middleware` - Receives every event and corresponding state. Useful for analytics, error handling, and other side effects.
 
 ## State
 
@@ -95,29 +114,29 @@ struct Update<T>: Event {
 }
 ```
 
-## Tying it Together with the Reactor
+## Tying it Together with the Core
 
-So, how does the state get events? Since the `Reactor` is responsible for all `State` changes, you can send events to the reactor which will in turn update the state by calling `react(to event: Event)` on the root state. You can create a shared global `Reactor` used by your entire application (my suggestion), or tediously pass the reference from object to object if you're a masochist.
+So, how does the state get events? Since the `Core` is responsible for all `State` changes, you can send events to the core which will in turn update the state by calling `react(to event: Event)` on the root state. You can create a shared global `Core` used by your entire application (my suggestion), or tediously pass the reference from object to object if you're a masochist.
 
 Here is an example of a simple view controller with a label displaying our intrepid character's level, and a "Level Up" button.
 
 ```swift
 class PlayerViewController: UIViewController {
-    var reactor = App.sharedReactor
+    var core = App.sharedCore
     @IBOutlet weak var levelLabel: UILabel!
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        reactor.add(subscriber: self)
+        core.add(subscriber: self)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        reactor.remove(subscriber: self)
+        core.remove(subscriber: self)
     }
 
     @IBAction func didPressLevelUp() {
-        reactor.fire(event: LevelUp())
+        core.fire(event: LevelUp())
     }
 }
 
@@ -128,36 +147,36 @@ extension ViewController: Subscriber {
 }
 ```
 
-By subscribing and subscribing in `viewDidAppear`/`viewDidDisappear` respectively, we ensure that whenever this view controller is visible it is up to date with the latest application state. Upon initial subscription, the reactor will send the latest state to the subscriber's `update` function. Button presses forward events back to the reactor, which will then update the state and result in subsequent calls to `update`. (note: the Reactor always dispatches back to the main thread when it updates subscribers, so it is safe to perform UI updates in `update`.)
+By subscribing and subscribing in `viewDidAppear`/`viewDidDisappear` respectively, we ensure that whenever this view controller is visible it is up to date with the latest application state. Upon initial subscription, the core will send the latest state to the subscriber's `update` function. Button presses forward events back to the ore, which will then update the state and result in subsequent calls to `update`. (note: the `Core` always dispatches back to the main thread when it updates subscribers, so it is safe to perform UI updates in `update`.)
 
 ## Commands
 
-Sometimes you want to fire an `Event` at a later point, for example after a network request, database query, or other asynchronous operation. In these cases, `Command` helps you interact with the `Reactor` in a safe and consistent way.
+Sometimes you want to fire an `Event` at a later point, for example after a network request, database query, or other asynchronous operation. In these cases, `Command` helps you interact with the `Core` in a safe and consistent way.
 
 ```swift
 struct CreatePlayer: Command {
     var session = URLSession.shared
     var player: Player
 
-    func execute(state: RPGState, reactor: Reactor<RPGState>) {
+    func execute(state: RPGState, core: Core<RPGState>) {
         let task = session.dataTask(with: player.createRequest()) { data, response, error in
             // handle response appropriately
-            // then fire an update back to the reactor
-            reactor.fire(event: AddPlayer(player: player))
+            // then fire an update back to the Core
+            core.fire(event: AddPlayer(player: player))
         }
         task.resume()
     }
 }
 
 // to fire a command
-reactor.fire(command: CreatePlayer(player: myNewPlayer))
+core.fire(command: CreatePlayer(player: myNewPlayer))
 ```
 
-Commands get a copy of the current state, and a reference to the Reactor so they can fire Events as necessary.
+Commands get a copy of the current state, and a reference to the Core so they can fire Events as necessary.
 
 ## Middleware
 
-Sometimes you want to do something with an event besides just update application state. This is where `Middleware` comes into play. When you create a `Reactor`, along with the initial state, you may pass in an array of middleware. Each middleware gets called every time an event is passed in. Middleware is not allowed to mutate the state, but it does get a copy of the state along with the event. Middleware makes it easy to add things like logging, analytics, and error handling to an application.
+Sometimes you want to do something with an event besides just update application state. This is where `Middleware` comes into play. When you create a `Core`, along with the initial state, you may pass in an array of middleware. Each middleware gets called every time an event is passed in. Middleware is not allowed to mutate the state, but it does get a copy of the state along with the event. Middleware makes it easy to add things like logging, analytics, and error handling to an application.
 
 ```swift
 struct LoggingMiddleware: Middleware {

--- a/Sources/Reactor.swift
+++ b/Sources/Reactor.swift
@@ -19,7 +19,7 @@ public protocol Event {}
 
 public protocol Command {
     associatedtype StateType: State
-    func execute(state: StateType, reactor: Reactor<StateType>)
+    func execute(state: StateType, core: Core<StateType>)
 }
 
 
@@ -73,9 +73,9 @@ public struct Subscription<StateType: State> {
 
 
 
-// MARK: - Reactor
+// MARK: - Core
 
-public class Reactor<StateType: State> {
+public class Core<StateType: State> {
     
     private var subscriptions = [Subscription<StateType>]()
     private var middlewares = [Middlewares<StateType>]()
@@ -89,8 +89,7 @@ public class Reactor<StateType: State> {
             }
         }
     }
-  
-  
+    
     public init(state: StateType, middlewares: [AnyMiddleware] = []) {
         self.state = state
         self.middlewares = middlewares.map(Middlewares.init)
@@ -125,7 +124,7 @@ public class Reactor<StateType: State> {
     }
     
     public func fire<C: Command>(command: C) where C.StateType == StateType {
-        command.execute(state: state, reactor: self)
+        command.execute(state: state, core: self)
     }
     
 }

--- a/Sources/Reactor.swift
+++ b/Sources/Reactor.swift
@@ -42,7 +42,7 @@ extension Middleware {
     }
 }
 
-public struct Middlewares<ReactorState: State> {
+public struct Middlewares<StateType: State> {
     private(set) var middleware: AnyMiddleware
 }
 

--- a/Sources/Reactor.swift
+++ b/Sources/Reactor.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 
-
 // MARK: - State
 
 public protocol State {

--- a/Sources/Reactor.swift
+++ b/Sources/Reactor.swift
@@ -15,7 +15,6 @@ public protocol Event {}
 
 // MARK: - Commands
 
-
 public protocol Command {
     associatedtype StateType: State
     func execute(state: StateType, core: Core<StateType>)


### PR DESCRIPTION
One of the problems Reactor is facing is due to how Swift handles importing. Specifically, if you are importing Reactor, and already have a local type named `Event`, `Command`, `State`, etc., then there is no way to tell Swift which one you are talking about.

Normally, you could prefix the type's name with it's package (i.e. `Reactor.State` or `MyApp.State`), but since the package name _and_ the class name are `Reactor`, when you import Reactor, you can not actually refer to Reactor's types by with their namespaces because the compiler thinks you're talking about `Reactor` the class, which has no internal types of `Event`, `State`, etc.

There are really two options available: rename the package, or rename the `Reactor` class. This PR follows the latter proposing that the `Reactor` class be renamed `Core`. I'm not a nuclear physicist, so the analogy may not be 100% there, but it makes sense to me. According to wikipedia the core is where all the reactions actually take place, so I think it is an appropriate name.
