### PR TITLE
Use Bart's serial queue and consolidate publishing

### DIFF
--- a/Sources/Reactor.swift
+++ b/Sources/Reactor.swift
@@ -67,6 +67,7 @@ extension Subscriber {
 public struct Subscription<StateType: State> {
     private(set) weak var subscriber: AnySubscriber? = nil
     let selector: ((StateType) -> Any)?
+    let useMainQueue: Bool
 }
 
 
@@ -75,15 +76,29 @@ public struct Subscription<StateType: State> {
 
 public class Core<StateType: State> {
     
-    private var subscriptions = [Subscription<StateType>]()
-    private var middlewares = [Middlewares<StateType>]()
+    private let jobQueue:DispatchQueue = DispatchQueue(label: "reactor.core.queue", qos: .userInitiated, attributes: [])
+
+    private let subscriptionsSyncQueue = DispatchQueue(label: "reactor.core.subscription.sync")
+    private var _subscriptions = [Subscription<StateType>]()
+    private var subscriptions: [Subscription<StateType>] {
+        get {
+            return subscriptionsSyncQueue.sync {
+                return self._subscriptions
+            }
+        }
+        set {
+            subscriptionsSyncQueue.sync {
+                self._subscriptions = newValue
+            }
+        }
+    }
+
+    private let middlewares: [Middlewares<StateType>]
     public private (set) var state: StateType {
         didSet {
             subscriptions = subscriptions.filter { $0.subscriber != nil }
-            DispatchQueue.main.async {
-                for subscription in self.subscriptions {
-                    self.publishStateChange(subscriber: subscription.subscriber, selector: subscription.selector)
-                }
+            for subscription in self.subscriptions {
+                self.publishStateChange(subscriber: subscription.subscriber, selector: subscription.selector, notifyOnMainQueue: subscription.useMainQueue)
             }
         }
     }
@@ -96,33 +111,42 @@ public class Core<StateType: State> {
     
     // MARK: - Subscriptions
     
-    public func add(subscriber: AnySubscriber, selector: ((StateType) -> Any)? = nil) {
+    public func add(subscriber: AnySubscriber, notifyOnMainQueue: Bool = true, selector: ((StateType) -> Any)? = nil) {
         guard !subscriptions.contains(where: {$0.subscriber === subscriber}) else { return }
-        subscriptions.append(Subscription(subscriber: subscriber, selector: selector))
-        publishStateChange(subscriber: subscriber, selector: selector)
+        subscriptions.append(Subscription(subscriber: subscriber, selector: selector, useMainQueue: notifyOnMainQueue))
+        publishStateChange(subscriber: subscriber, selector: selector, notifyOnMainQueue: notifyOnMainQueue)
     }
     
     public func remove(subscriber: AnySubscriber) {
         subscriptions = subscriptions.filter { $0.subscriber !== subscriber }
     }
     
-    private func publishStateChange(subscriber: AnySubscriber?, selector: ((StateType) -> Any)?) {
-        if let selector = selector {
-            subscriber?._update(with: selector(self.state))
-        } else {
-            subscriber?._update(with: self.state)
+    private func publishStateChange(subscriber: AnySubscriber?, selector: ((StateType) -> Any)?, notifyOnMainQueue: Bool) {
+        let state = self.state
+        let queue = notifyOnMainQueue ? DispatchQueue.main : jobQueue
+        queue.async {
+            if let selector = selector {
+                subscriber?._update(with: selector(state))
+            } else {
+                subscriber?._update(with: state)
+            }
         }
     }
     
     // MARK: - Events
     
     public func fire(event: Event) {
-        state.react(to: event)
-        middlewares.forEach { $0.middleware._process(event: event, state: state) }
+        jobQueue.async {
+            self.state.react(to: event)
+            let state = self.state
+            self.middlewares.forEach { $0.middleware._process(event: event, state: state) }
+        }
     }
     
     public func fire<C: Command>(command: C) where C.StateType == StateType {
-        command.execute(state: state, core: self)
+        jobQueue.async {
+            command.execute(state: self.state, core: self)
+        }
     }
     
 }


### PR DESCRIPTION
Pushing the work into a serial queue helps keep guarantees of completely processing events in-order. Simplifying the publishing into `Subscription` gives that concept weight and consistent use in the file.