### PR TITLE
Fix for race condition

### DIFF
--- a/Sources/Reactor.swift
+++ b/Sources/Reactor.swift
@@ -122,7 +122,7 @@ public class Core<StateType: State> {
     // MARK: - Subscriptions
     
     public func add(subscriber: AnySubscriber, notifyOnQueue queue: DispatchQueue? = DispatchQueue.main, selector: ((StateType) -> Any)? = nil) {
-        jobQueue.async {
+        jobQueue.sync {
             guard !self.subscriptions.contains(where: {$0.subscriber === subscriber}) else { return }
             let subscription = Subscription(subscriber: subscriber, selector: selector, notifyQueue: queue ?? self.jobQueue)
             self.subscriptions.append(subscription)


### PR DESCRIPTION
We ran into a race condition where a viewController can subscribe upon loading, update and before the subscription gets added to the subscription list, an event can be fired with an update. The result is that the ViewController doesn't get updated for that event.
In our case, we are blocking the UI while we fire a command to tell us what segue to fire and that command is finishing before the viewController is added to the list of subscriptions in certain conditions, leaving the ViewController indefinitely frozen. From our testing, this fix should rectify that problem.