### PR TITLE
Fix threading issues

### DIFF
--- a/Reactor.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Reactor.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/ReactorTests/ReactorTests.swift
+++ b/Tests/ReactorTests/ReactorTests.swift
@@ -1,17 +1,113 @@
 import XCTest
 @testable import Reactor
 
-class ReactorTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        
+// describe Reactor
+
+// when it has many clients
+class WhenReactorHasManyClients: XCTestCase {
+
+    // it guarantees subscribers receive their own events
+    func testReactorGuaranteesSubscribersReceiveTheirOwnEvents() {
+        let core = Core(state: TestState())
+
+        var subscribers = [TestSubscriber]()
+        for index in 0..<1000 {
+            subscribers.append(TestSubscriber(id: index))
+        }
+        let predicate = NSPredicate { _, _ -> Bool in
+            return subscribers.reduce(true, { $0 && $1.received })
+        }
+        let expected = expectation(for: predicate, evaluatedWith: NSObject())
+
+        let globalQueue = DispatchQueue.global()
+        globalQueue.async {
+            DispatchQueue.concurrentPerform(iterations: subscribers.count) { index in
+                let subscriber = subscribers[index]
+                let event = TestEvent(id: subscriber.id)
+                core.add(subscriber: subscriber)
+                core.fire(event: event)
+                core.remove(subscriber: subscriber)
+            }
+        }
+
+        wait(for: [expected], timeout: 5.0)
+        XCTAssertEqual(subscribers.count, subscribers.reduce(0, { $0 + ($1.received ? 1 : 0)}))
     }
 
+    // it guarantees subscribers receive their own commands
+    func testReactorGuaranteesSubscribersReceiveTheirOwnCommands() {
+        let core = Core(state: TestState())
 
-    static var allTests : [(String, (ReactorTests) -> () throws -> Void)] {
-        return [
-            ("testExample", testExample),
-        ]
+        var subscribers = [TestSubscriber]()
+        for index in 0..<1000 {
+            subscribers.append(TestSubscriber(id: index))
+        }
+        let predicate = NSPredicate { _, _ -> Bool in
+            return subscribers.reduce(true, { $0 && $1.received })
+        }
+        let expected = expectation(for: predicate, evaluatedWith: NSObject())
+
+        let globalQueue = DispatchQueue.global()
+        globalQueue.async {
+            DispatchQueue.concurrentPerform(iterations: subscribers.count) { index in
+                let subscriber = subscribers[index]
+                let command = TestCommand(id: subscriber.id)
+                core.add(subscriber: subscriber)
+                core.fire(command: command)
+                // don't remove them so that the async commands can run
+            }
+        }
+
+        wait(for: [expected], timeout: 5.0)
+        XCTAssertEqual(subscribers.count, subscribers.reduce(0, { $0 + ($1.received ? 1 : 0)}))
+        print(subscribers.filter { !$0.received }.map { String(describing: $0) }.joined(separator: ", "))
     }
+
+}
+
+
+struct TestState: State {
+
+    var latest = -1
+
+    mutating func react(to event: Event) {
+        switch event {
+        case let e as TestEvent:
+            self.latest = e.id
+        default:
+            break
+        }
+    }
+
+}
+
+struct TestEvent: Event {
+    let id: Int
+}
+
+struct TestCommand: Command {
+
+    let id: Int
+
+    func execute(state: TestState, core: Core<TestState>) {
+        core.fire(event: TestEvent(id: id))
+    }
+
+}
+
+class TestSubscriber: Subscriber {
+
+    let id: Int
+    var received = false
+
+    init(id: Int) {
+        self.id = id
+    }
+
+    func update(with state: TestState) {
+        if state.latest == id {
+            received = true
+        }
+    }
+
 }


### PR DESCRIPTION
The extra queue protecting the subscriptions was _almost_
always wrapped by the jobQueue, and when it wasn't it should
have been. The jobQueue is now the sole way to order requests,
and the logic is much simpler.